### PR TITLE
chore: jx-go-loops to 0.0.2

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -10,3 +10,6 @@ dependencies:
 - name: help
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.1.0
+- name: jx-go-loops
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 0.0.2


### PR DESCRIPTION
chore: Promote jx-go-loops to version 0.0.2